### PR TITLE
Fix formatting mismatch in Lyft Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 `LyftSDK` adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.2](https://github.com/lyft/Lyft-iOS-sdk/releases/tag/1.0.2)
+
+Fix formatting mismatch in Lyft Button
+
 ## [1.0.1](https://github.com/lyft/Lyft-iOS-sdk/releases/tag/1.0.1)
 
 Linter fixes in preparation for podspec upload

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - LyftSDK (1.0.0):
-    - LyftSDK/Core (= 1.0.0)
-  - LyftSDK/Core (1.0.0)
+  - LyftSDK (1.0.2):
+    - LyftSDK/Core (= 1.0.2)
+  - LyftSDK/Core (1.0.2)
   - OHHTTPStubs (5.2.1):
     - OHHTTPStubs/Default (= 5.2.1)
   - OHHTTPStubs/Core (5.2.1)
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  LyftSDK: 9ff30189b715d0352c2dca8d298f0eb2f7c31c8b
+  LyftSDK: 2dbb4a96fdbf26b6bdd2b14fd4f41509bf472942
   OHHTTPStubs: 3a42f25c00563b71355ac73112ba2324e9e6cef4
 
 PODFILE CHECKSUM: 9ba4e26754fb7c0714263aaa9a831f1d0eeaa91e

--- a/LyftSDK.podspec
+++ b/LyftSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = 'LyftSDK'
-  s.version         = '1.0.1'
+  s.version         = '1.0.2'
   s.summary         = 'The official Lyft iOS SDK.'
   s.homepage        = 'https://github.com/lyft/lyft-iOS-sdk'
   s.license         = { :type => 'Apache', :file => 'LICENSE' }

--- a/Sources/LyftUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/LyftUI/Resources/en.lproj/Localizable.strings
@@ -1,2 +1,2 @@
-"RIDE_ETA_FORMAT" = "%@ in %@ min";
+"RIDE_ETA_FORMAT" = "%@ in %d min";
 "COST_ESTIMATE_RANGE_FORMAT" = "%@-%@";


### PR DESCRIPTION
The minutes attribute was formerly listed as a string. This was changed without changing the way it was used in formatting in `LyftButton`