### PR TITLE
Create framework project for manual importing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 `LyftSDK` adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.3](https://github.com/lyft/Lyft-iOS-sdk/releases/tag/1.0.3)
+
+- Create framework project that can be manually imported
+- Provide Carthage support
+
 ## [1.0.2](https://github.com/lyft/Lyft-iOS-sdk/releases/tag/1.0.2)
 
 Fix formatting mismatch in Lyft Button

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - LyftSDK (1.0.2):
-    - LyftSDK/Core (= 1.0.2)
-  - LyftSDK/Core (1.0.2)
+  - LyftSDK (1.0.3):
+    - LyftSDK/Core (= 1.0.3)
+  - LyftSDK/Core (1.0.3)
   - OHHTTPStubs (5.2.1):
     - OHHTTPStubs/Default (= 5.2.1)
   - OHHTTPStubs/Core (5.2.1)
@@ -25,9 +25,9 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  LyftSDK: 2dbb4a96fdbf26b6bdd2b14fd4f41509bf472942
+  LyftSDK: 36cb780cacc423d36d54ea06649e07337409c5b8
   OHHTTPStubs: 3a42f25c00563b71355ac73112ba2324e9e6cef4
 
 PODFILE CHECKSUM: 9ba4e26754fb7c0714263aaa9a831f1d0eeaa91e
 
-COCOAPODS: 1.1.0.rc.3
+COCOAPODS: 1.1.1

--- a/LyftSDK.podspec
+++ b/LyftSDK.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name            = 'LyftSDK'
-  s.version         = '1.0.2'
+  s.version         = '1.0.3'
   s.summary         = 'The official Lyft iOS SDK.'
   s.homepage        = 'https://github.com/lyft/lyft-iOS-sdk'
   s.license         = { :type => 'Apache', :file => 'LICENSE' }
-  s.author          = { 'Hyun Lim' => 'hlim@lyft.com' }
+  s.author          = { 'Gilad Gurantz' => 'gilad@lyft.com' }
   s.source          = { :git => 'https://github.com/lyft/lyft-iOS-sdk.git', :tag => s.version.to_s }
   s.default_subspec = 'Core'
   s.ios.deployment_target = '8.0'

--- a/LyftSDK.xcodeproj/project.pbxproj
+++ b/LyftSDK.xcodeproj/project.pbxproj
@@ -1,0 +1,570 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		FB7CA7211DD1252800303FEB /* LyftSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB7CA7171DD1252800303FEB /* LyftSDK.framework */; };
+		FB7CA7581DD1256800303FEB /* APIRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7351DD1256800303FEB /* APIRoute.swift */; };
+		FB7CA7591DD1256800303FEB /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7361DD1256800303FEB /* Bundle+Extension.swift */; };
+		FB7CA75A1DD1256800303FEB /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7371DD1256800303FEB /* HTTPClient.swift */; };
+		FB7CA75B1DD1256800303FEB /* JSONMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7381DD1256800303FEB /* JSONMappable.swift */; };
+		FB7CA75C1DD1256800303FEB /* LyftAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7391DD1256800303FEB /* LyftAPI.swift */; };
+		FB7CA75D1DD1256800303FEB /* LyftAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA73A1DD1256800303FEB /* LyftAPIError.swift */; };
+		FB7CA75E1DD1256800303FEB /* LyftAPIURLEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA73B1DD1256800303FEB /* LyftAPIURLEncoding.swift */; };
+		FB7CA75F1DD1256800303FEB /* LyftConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA73C1DD1256800303FEB /* LyftConfiguration.swift */; };
+		FB7CA7601DD1256800303FEB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA73D1DD1256800303FEB /* Result.swift */; };
+		FB7CA7611DD1256800303FEB /* CLLocationCoordinate2D+JSONMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA73F1DD1256800303FEB /* CLLocationCoordinate2D+JSONMappable.swift */; };
+		FB7CA7621DD1256800303FEB /* Cost.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7401DD1256800303FEB /* Cost.swift */; };
+		FB7CA7631DD1256800303FEB /* ETA.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7411DD1256800303FEB /* ETA.swift */; };
+		FB7CA7641DD1256800303FEB /* Money.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7421DD1256800303FEB /* Money.swift */; };
+		FB7CA7651DD1256800303FEB /* NearbyDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7431DD1256800303FEB /* NearbyDriver.swift */; };
+		FB7CA7661DD1256800303FEB /* PricingDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7441DD1256800303FEB /* PricingDetails.swift */; };
+		FB7CA7671DD1256800303FEB /* RideKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7451DD1256800303FEB /* RideKind.swift */; };
+		FB7CA7681DD1256800303FEB /* RideType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7461DD1256800303FEB /* RideType.swift */; };
+		FB7CA7691DD1256800303FEB /* Asset.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7481DD1256800303FEB /* Asset.swift */; };
+		FB7CA76A1DD1256800303FEB /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7491DD1256800303FEB /* Button.swift */; };
+		FB7CA76B1DD1256800303FEB /* I18N.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA74A1DD1256800303FEB /* I18N.swift */; };
+		FB7CA76C1DD1256800303FEB /* LyftButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA74B1DD1256800303FEB /* LyftButton.swift */; };
+		FB7CA76D1DD1256800303FEB /* LyftButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA74C1DD1256800303FEB /* LyftButtonStyle.swift */; };
+		FB7CA76E1DD1256800303FEB /* LyftDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA74D1DD1256800303FEB /* LyftDeepLink.swift */; };
+		FB7CA76F1DD1256800303FEB /* Money+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA74E1DD1256800303FEB /* Money+UI.swift */; };
+		FB7CA7701DD1256800303FEB /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = FB7CA7501DD1256800303FEB /* Localizable.strings */; };
+		FB7CA7711DD1256800303FEB /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FB7CA7521DD1256800303FEB /* Images.xcassets */; };
+		FB7CA7721DD1256800303FEB /* LyftButtonFull.xib in Resources */ = {isa = PBXBuildFile; fileRef = FB7CA7531DD1256800303FEB /* LyftButtonFull.xib */; };
+		FB7CA7731DD1256800303FEB /* LyftButtonNone.xib in Resources */ = {isa = PBXBuildFile; fileRef = FB7CA7541DD1256800303FEB /* LyftButtonNone.xib */; };
+		FB7CA7741DD1256800303FEB /* LyftButtonRideTypeETA.xib in Resources */ = {isa = PBXBuildFile; fileRef = FB7CA7551DD1256800303FEB /* LyftButtonRideTypeETA.xib */; };
+		FB7CA7751DD1256800303FEB /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7561DD1256800303FEB /* UIColor+Extension.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		FB7CA7221DD1252800303FEB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB7CA70E1DD1252800303FEB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB7CA7161DD1252800303FEB;
+			remoteInfo = LyftSDK;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		FB7CA7171DD1252800303FEB /* LyftSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LyftSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FB7CA7201DD1252800303FEB /* LyftSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LyftSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FB7CA7321DD1256800303FEB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FB7CA7351DD1256800303FEB /* APIRoute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIRoute.swift; sourceTree = "<group>"; };
+		FB7CA7361DD1256800303FEB /* Bundle+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Extension.swift"; sourceTree = "<group>"; };
+		FB7CA7371DD1256800303FEB /* HTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
+		FB7CA7381DD1256800303FEB /* JSONMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONMappable.swift; sourceTree = "<group>"; };
+		FB7CA7391DD1256800303FEB /* LyftAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LyftAPI.swift; sourceTree = "<group>"; };
+		FB7CA73A1DD1256800303FEB /* LyftAPIError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LyftAPIError.swift; sourceTree = "<group>"; };
+		FB7CA73B1DD1256800303FEB /* LyftAPIURLEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LyftAPIURLEncoding.swift; sourceTree = "<group>"; };
+		FB7CA73C1DD1256800303FEB /* LyftConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LyftConfiguration.swift; sourceTree = "<group>"; };
+		FB7CA73D1DD1256800303FEB /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		FB7CA73F1DD1256800303FEB /* CLLocationCoordinate2D+JSONMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLLocationCoordinate2D+JSONMappable.swift"; sourceTree = "<group>"; };
+		FB7CA7401DD1256800303FEB /* Cost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cost.swift; sourceTree = "<group>"; };
+		FB7CA7411DD1256800303FEB /* ETA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ETA.swift; sourceTree = "<group>"; };
+		FB7CA7421DD1256800303FEB /* Money.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Money.swift; sourceTree = "<group>"; };
+		FB7CA7431DD1256800303FEB /* NearbyDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NearbyDriver.swift; sourceTree = "<group>"; };
+		FB7CA7441DD1256800303FEB /* PricingDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PricingDetails.swift; sourceTree = "<group>"; };
+		FB7CA7451DD1256800303FEB /* RideKind.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RideKind.swift; sourceTree = "<group>"; };
+		FB7CA7461DD1256800303FEB /* RideType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RideType.swift; sourceTree = "<group>"; };
+		FB7CA7481DD1256800303FEB /* Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Asset.swift; sourceTree = "<group>"; };
+		FB7CA7491DD1256800303FEB /* Button.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
+		FB7CA74A1DD1256800303FEB /* I18N.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = I18N.swift; sourceTree = "<group>"; };
+		FB7CA74B1DD1256800303FEB /* LyftButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LyftButton.swift; sourceTree = "<group>"; };
+		FB7CA74C1DD1256800303FEB /* LyftButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LyftButtonStyle.swift; sourceTree = "<group>"; };
+		FB7CA74D1DD1256800303FEB /* LyftDeepLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LyftDeepLink.swift; sourceTree = "<group>"; };
+		FB7CA74E1DD1256800303FEB /* Money+UI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Money+UI.swift"; sourceTree = "<group>"; };
+		FB7CA7511DD1256800303FEB /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FB7CA7521DD1256800303FEB /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		FB7CA7531DD1256800303FEB /* LyftButtonFull.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LyftButtonFull.xib; sourceTree = "<group>"; };
+		FB7CA7541DD1256800303FEB /* LyftButtonNone.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LyftButtonNone.xib; sourceTree = "<group>"; };
+		FB7CA7551DD1256800303FEB /* LyftButtonRideTypeETA.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LyftButtonRideTypeETA.xib; sourceTree = "<group>"; };
+		FB7CA7561DD1256800303FEB /* UIColor+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FB7CA7131DD1252800303FEB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB7CA71D1DD1252800303FEB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB7CA7211DD1252800303FEB /* LyftSDK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		FB7CA70D1DD1252800303FEB = {
+			isa = PBXGroup;
+			children = (
+				FB7CA7311DD1256800303FEB /* Resources */,
+				FB7CA7331DD1256800303FEB /* Sources */,
+				FB7CA7181DD1252800303FEB /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		FB7CA7181DD1252800303FEB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FB7CA7171DD1252800303FEB /* LyftSDK.framework */,
+				FB7CA7201DD1252800303FEB /* LyftSDKTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FB7CA7311DD1256800303FEB /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FB7CA7321DD1256800303FEB /* Info.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		FB7CA7331DD1256800303FEB /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				FB7CA7341DD1256800303FEB /* LyftAPI */,
+				FB7CA73E1DD1256800303FEB /* LyftModels */,
+				FB7CA7471DD1256800303FEB /* LyftUI */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		FB7CA7341DD1256800303FEB /* LyftAPI */ = {
+			isa = PBXGroup;
+			children = (
+				FB7CA7351DD1256800303FEB /* APIRoute.swift */,
+				FB7CA7361DD1256800303FEB /* Bundle+Extension.swift */,
+				FB7CA7371DD1256800303FEB /* HTTPClient.swift */,
+				FB7CA7381DD1256800303FEB /* JSONMappable.swift */,
+				FB7CA7391DD1256800303FEB /* LyftAPI.swift */,
+				FB7CA73A1DD1256800303FEB /* LyftAPIError.swift */,
+				FB7CA73B1DD1256800303FEB /* LyftAPIURLEncoding.swift */,
+				FB7CA73C1DD1256800303FEB /* LyftConfiguration.swift */,
+				FB7CA73D1DD1256800303FEB /* Result.swift */,
+			);
+			path = LyftAPI;
+			sourceTree = "<group>";
+		};
+		FB7CA73E1DD1256800303FEB /* LyftModels */ = {
+			isa = PBXGroup;
+			children = (
+				FB7CA73F1DD1256800303FEB /* CLLocationCoordinate2D+JSONMappable.swift */,
+				FB7CA7401DD1256800303FEB /* Cost.swift */,
+				FB7CA7411DD1256800303FEB /* ETA.swift */,
+				FB7CA7421DD1256800303FEB /* Money.swift */,
+				FB7CA7431DD1256800303FEB /* NearbyDriver.swift */,
+				FB7CA7441DD1256800303FEB /* PricingDetails.swift */,
+				FB7CA7451DD1256800303FEB /* RideKind.swift */,
+				FB7CA7461DD1256800303FEB /* RideType.swift */,
+			);
+			path = LyftModels;
+			sourceTree = "<group>";
+		};
+		FB7CA7471DD1256800303FEB /* LyftUI */ = {
+			isa = PBXGroup;
+			children = (
+				FB7CA7481DD1256800303FEB /* Asset.swift */,
+				FB7CA7491DD1256800303FEB /* Button.swift */,
+				FB7CA74A1DD1256800303FEB /* I18N.swift */,
+				FB7CA74B1DD1256800303FEB /* LyftButton.swift */,
+				FB7CA74C1DD1256800303FEB /* LyftButtonStyle.swift */,
+				FB7CA74D1DD1256800303FEB /* LyftDeepLink.swift */,
+				FB7CA74E1DD1256800303FEB /* Money+UI.swift */,
+				FB7CA74F1DD1256800303FEB /* Resources */,
+				FB7CA7561DD1256800303FEB /* UIColor+Extension.swift */,
+			);
+			path = LyftUI;
+			sourceTree = "<group>";
+		};
+		FB7CA74F1DD1256800303FEB /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FB7CA7501DD1256800303FEB /* Localizable.strings */,
+				FB7CA7521DD1256800303FEB /* Images.xcassets */,
+				FB7CA7531DD1256800303FEB /* LyftButtonFull.xib */,
+				FB7CA7541DD1256800303FEB /* LyftButtonNone.xib */,
+				FB7CA7551DD1256800303FEB /* LyftButtonRideTypeETA.xib */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		FB7CA7141DD1252800303FEB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		FB7CA7161DD1252800303FEB /* LyftSDK */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB7CA72B1DD1252800303FEB /* Build configuration list for PBXNativeTarget "LyftSDK" */;
+			buildPhases = (
+				FB7CA7121DD1252800303FEB /* Sources */,
+				FB7CA7131DD1252800303FEB /* Frameworks */,
+				FB7CA7141DD1252800303FEB /* Headers */,
+				FB7CA7151DD1252800303FEB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LyftSDK;
+			productName = LyftSDK;
+			productReference = FB7CA7171DD1252800303FEB /* LyftSDK.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		FB7CA71F1DD1252800303FEB /* LyftSDKTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB7CA72E1DD1252800303FEB /* Build configuration list for PBXNativeTarget "LyftSDKTests" */;
+			buildPhases = (
+				FB7CA71C1DD1252800303FEB /* Sources */,
+				FB7CA71D1DD1252800303FEB /* Frameworks */,
+				FB7CA71E1DD1252800303FEB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FB7CA7231DD1252800303FEB /* PBXTargetDependency */,
+			);
+			name = LyftSDKTests;
+			productName = LyftSDKTests;
+			productReference = FB7CA7201DD1252800303FEB /* LyftSDKTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		FB7CA70E1DD1252800303FEB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0810;
+				LastUpgradeCheck = 0810;
+				ORGANIZATIONNAME = Lyft;
+				TargetAttributes = {
+					FB7CA7161DD1252800303FEB = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Manual;
+					};
+					FB7CA71F1DD1252800303FEB = {
+						CreatedOnToolsVersion = 8.1;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = FB7CA7111DD1252800303FEB /* Build configuration list for PBXProject "LyftSDK" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = FB7CA70D1DD1252800303FEB;
+			productRefGroup = FB7CA7181DD1252800303FEB /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				FB7CA7161DD1252800303FEB /* LyftSDK */,
+				FB7CA71F1DD1252800303FEB /* LyftSDKTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		FB7CA7151DD1252800303FEB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB7CA7711DD1256800303FEB /* Images.xcassets in Resources */,
+				FB7CA7721DD1256800303FEB /* LyftButtonFull.xib in Resources */,
+				FB7CA7741DD1256800303FEB /* LyftButtonRideTypeETA.xib in Resources */,
+				FB7CA7731DD1256800303FEB /* LyftButtonNone.xib in Resources */,
+				FB7CA7701DD1256800303FEB /* Localizable.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB7CA71E1DD1252800303FEB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		FB7CA7121DD1252800303FEB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB7CA7691DD1256800303FEB /* Asset.swift in Sources */,
+				FB7CA7621DD1256800303FEB /* Cost.swift in Sources */,
+				FB7CA76F1DD1256800303FEB /* Money+UI.swift in Sources */,
+				FB7CA7601DD1256800303FEB /* Result.swift in Sources */,
+				FB7CA75D1DD1256800303FEB /* LyftAPIError.swift in Sources */,
+				FB7CA7671DD1256800303FEB /* RideKind.swift in Sources */,
+				FB7CA76A1DD1256800303FEB /* Button.swift in Sources */,
+				FB7CA7641DD1256800303FEB /* Money.swift in Sources */,
+				FB7CA75F1DD1256800303FEB /* LyftConfiguration.swift in Sources */,
+				FB7CA7751DD1256800303FEB /* UIColor+Extension.swift in Sources */,
+				FB7CA76D1DD1256800303FEB /* LyftButtonStyle.swift in Sources */,
+				FB7CA76C1DD1256800303FEB /* LyftButton.swift in Sources */,
+				FB7CA75C1DD1256800303FEB /* LyftAPI.swift in Sources */,
+				FB7CA76B1DD1256800303FEB /* I18N.swift in Sources */,
+				FB7CA7661DD1256800303FEB /* PricingDetails.swift in Sources */,
+				FB7CA7581DD1256800303FEB /* APIRoute.swift in Sources */,
+				FB7CA7611DD1256800303FEB /* CLLocationCoordinate2D+JSONMappable.swift in Sources */,
+				FB7CA75B1DD1256800303FEB /* JSONMappable.swift in Sources */,
+				FB7CA7591DD1256800303FEB /* Bundle+Extension.swift in Sources */,
+				FB7CA7651DD1256800303FEB /* NearbyDriver.swift in Sources */,
+				FB7CA75A1DD1256800303FEB /* HTTPClient.swift in Sources */,
+				FB7CA7631DD1256800303FEB /* ETA.swift in Sources */,
+				FB7CA76E1DD1256800303FEB /* LyftDeepLink.swift in Sources */,
+				FB7CA7681DD1256800303FEB /* RideType.swift in Sources */,
+				FB7CA75E1DD1256800303FEB /* LyftAPIURLEncoding.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB7CA71C1DD1252800303FEB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		FB7CA7231DD1252800303FEB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB7CA7161DD1252800303FEB /* LyftSDK */;
+			targetProxy = FB7CA7221DD1252800303FEB /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		FB7CA7501DD1256800303FEB /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FB7CA7511DD1256800303FEB /* en */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		FB7CA7291DD1252800303FEB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FB7CA72A1DD1252800303FEB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		FB7CA72C1DD1252800303FEB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.LyftSDK;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0.1;
+			};
+			name = Debug;
+		};
+		FB7CA72D1DD1252800303FEB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Resources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.LyftSDK;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0.1;
+			};
+			name = Release;
+		};
+		FB7CA72F1DD1252800303FEB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				INFOPLIST_FILE = LyftSDKTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.LyftSDKTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		FB7CA7301DD1252800303FEB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				INFOPLIST_FILE = LyftSDKTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.LyftSDKTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		FB7CA7111DD1252800303FEB /* Build configuration list for PBXProject "LyftSDK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FB7CA7291DD1252800303FEB /* Debug */,
+				FB7CA72A1DD1252800303FEB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FB7CA72B1DD1252800303FEB /* Build configuration list for PBXNativeTarget "LyftSDK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FB7CA72C1DD1252800303FEB /* Debug */,
+				FB7CA72D1DD1252800303FEB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FB7CA72E1DD1252800303FEB /* Build configuration list for PBXNativeTarget "LyftSDKTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FB7CA72F1DD1252800303FEB /* Debug */,
+				FB7CA7301DD1252800303FEB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = FB7CA70E1DD1252800303FEB /* Project object */;
+}

--- a/LyftSDK.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/LyftSDK.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:LyftSDK.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/LyftSDK.xcodeproj/xcshareddata/xcschemes/LyftSDK.xcscheme
+++ b/LyftSDK.xcodeproj/xcshareddata/xcschemes/LyftSDK.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FB7CA7161DD1252800303FEB"
+               BuildableName = "LyftSDK.framework"
+               BlueprintName = "LyftSDK"
+               ReferencedContainer = "container:LyftSDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FB7CA71F1DD1252800303FEB"
+               BuildableName = "LyftSDKTests.xctest"
+               BlueprintName = "LyftSDKTests"
+               ReferencedContainer = "container:LyftSDK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FB7CA7161DD1252800303FEB"
+            BuildableName = "LyftSDK.framework"
+            BlueprintName = "LyftSDK"
+            ReferencedContainer = "container:LyftSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FB7CA7161DD1252800303FEB"
+            BuildableName = "LyftSDK.framework"
+            BlueprintName = "LyftSDK"
+            ReferencedContainer = "container:LyftSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FB7CA7161DD1252800303FEB"
+            BuildableName = "LyftSDK.framework"
+            BlueprintName = "LyftSDK"
+            ReferencedContainer = "container:LyftSDK.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ $ pod install
 pod 'LyftSDK/API'
 ```
 
+### Carthage
+
+[Carthage](https://github.com/Carthage/Carthage) is a simple, decentralized dependency manager for Cocoa. To import this SDK, add this to your Cartfile:
+
+```
+github "lyft/Lyft-iOS-sdk"
+```
+
+### Integrate without dependency manager
+
+Drag the LyftSDK.xcodeproj project into your project's Project Navigator. In your project's Build Target, click on the General tab and then under Embedded Binaries click the + button. Select the LyftSDK.framework under your project.
+
 ## Usage
 
 ### SDK Configuration

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.3</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Sources/LyftAPI/JSONMappable.swift
+++ b/Sources/LyftAPI/JSONMappable.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Represents an object that can be created from a json object
 protocol JSONMappable {
 
@@ -13,11 +15,11 @@ protocol JSONMappable {
     /// - parameter json:   The untyped json object to initialize this object with
     ///
     /// - returns:  An instance of this object if one can be created, or nil otherwise
-    init?(json: Any)
+    init?(json: Any?)
 }
 
 extension JSONMappable {
-    init?(json: Any) {
+    init?(json: Any?) {
         if let json = json as? NSDictionary {
             self.init(json: json)
         } else {
@@ -33,7 +35,7 @@ extension Array where Element: JSONMappable {
     /// - parameter json:   The json object representing the array of mappable items
     ///
     /// - returns:  An array of mapped items if one can be created, or nil otherwise
-    init?(json: Any) {
+    init?(json: Any?) {
         if let json = json as? [NSDictionary], json.count > 0 {
             self = json.flatMap { Element(json: $0) }
         } else {

--- a/Sources/LyftModels/Cost.swift
+++ b/Sources/LyftModels/Cost.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Cost and detail estimations for a pickup and destination
 public struct RideCostEstimate {
     /// Maximum estimated cost

--- a/Sources/LyftModels/ETA.swift
+++ b/Sources/LyftModels/ETA.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Represents the estimated time in seconds it will take for the nearest driver to reach the specified
 /// location for a given ride type
 public struct ETA {

--- a/Sources/LyftModels/Money.swift
+++ b/Sources/LyftModels/Money.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Represents an amount of money with its corresponding currency code
 public struct Money {
     /// The amount of money represented. Based on the currencyCode used

--- a/Sources/LyftModels/PricingDetails.swift
+++ b/Sources/LyftModels/PricingDetails.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Pricing information related to a ride type
 public struct PricingDetails {
     /// The initial charge for a ride. This is the fee applied before ride specific costs

--- a/Sources/LyftModels/RideKind.swift
+++ b/Sources/LyftModels/RideKind.swift
@@ -18,7 +18,7 @@ public struct RideKind: RawRepresentable, Hashable {
     /// - parameter object: An untyped object likely from a json server response
     ///
     /// - returns:  A RideKind if one can be created, or nil
-    init?(object: Any) {
+    init?(object: Any?) {
         if let rawValue = object as? String {
             self = RideKind(rawValue: rawValue)
         } else {

--- a/Sources/LyftModels/RideType.swift
+++ b/Sources/LyftModels/RideType.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// The details of a ride type offered by the Lyft platform
 public struct RideType {
     /// The unique ride type key

--- a/Sources/LyftUI/I18N.swift
+++ b/Sources/LyftUI/I18N.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 private class BundleIdentifyingClass { }
 
 private func __(_ key: String) -> String {

--- a/Sources/LyftUI/LyftDeepLink.swift
+++ b/Sources/LyftUI/LyftDeepLink.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreLocation
+import UIKit
 
 /// Collection of deep links into the main Lyft application
 public struct LyftDeepLink {
@@ -55,6 +56,7 @@ public struct LyftDeepLink {
         }
     }
 
+    @available(iOS 10.0, *)
     private static func launchAppStore() {
         let signUp = LyftConfiguration.signUpIdentifier
         let id = LyftConfiguration.developer?.clientId ?? "unknown"
@@ -62,7 +64,7 @@ public struct LyftDeepLink {
         let version = infoDictionary?["CFBundleShortVersionString"] as? String ?? "?.?.?"
         let url = "https://www.lyft.com/signup/\(signUp)?clientId=\(id)&sdkName=iOS&sdkVersion=\(version)"
         if let signUpUrl = URL(string: url) {
-            UIApplication.shared.openURL(signUpUrl)
+            UIApplication.shared.open(signUpUrl, options: [:], completionHandler: nil)
         }
     }
 }

--- a/Sources/LyftUI/Money+UI.swift
+++ b/Sources/LyftUI/Money+UI.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 private let kFormatErrorRepresentation = "ERR"
 
 extension Money {


### PR DESCRIPTION
Created `LyftSDK.xcodeproj` in the parent directory for users who do not use a dependency manager. As a side effect, we now provide Carthage support as well!

Creating a framework exposed classes that did not import Foundation properly, and exposed an issue where we were including an iOS dependent file (`LyftDeeplink`) in the API import.