### PR TITLE
Fixed access management issue with URLComponents.

### DIFF
--- a/Sources/LyftAPI/LyftAPIURLEncoding.swift
+++ b/Sources/LyftAPI/LyftAPIURLEncoding.swift
@@ -29,7 +29,7 @@ func lyftURLEncodedInURL(request: URLRequest, parameters: [String: Any]?) -> (UR
         .flatMap { components(forKey: $0, value: $1) }
 
     var urlComponents = URLComponents(url: mutableURLRequest.url!, resolvingAgainstBaseURL: false)
-    urlComponents?.queryItems = (urlComponents?.queryItems ?? []) + queryItems
+	urlComponents?.queryItems?.append(contentsOf: queryItems)
     mutableURLRequest.url = urlComponents?.url
     return (mutableURLRequest, nil)
 }


### PR DESCRIPTION
Instead of overwriting the existing urlComponents.queryItems with itself and then adding the new queryItems variable on top of it. I appended the contents of the queryItems variable to urlComponents.queryItems. This fixes the access management issues, and results in slightly cleaner code.