### PR TITLE
Update to Swift 5 and lux ride kinds

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,27 +1,48 @@
 disabled_rules:
-  - force_cast
-  - function_body_length
-  - function_parameter_count
+  - identifier_name
   - opening_brace
-  - type_name
-  - variable_name
 opt_in_rules:
   - conditional_returns_on_newline
-  - redundant_nil_coalesing
+  - private_outlet
+  - sorted_imports
+trailing_comma:
+  mandatory_comma: true
 line_length:
   - 110
 type_body_length:
   - 350
+private_over_fileprivate:
+  validate_extensions: true
+deployment_target:
+  iOS_deployment_target: 8.0
 excluded:
   - Example/Pods
 
 custom_rules:
   extra_newlines_braces:
     name: "Extra newlines before closing braces"
-    regex: "\}\n\n\s*\}$"
+    regex: '\}\n\n\s*\}$'
   closure_arg_parens:
     name: "Closure argument no parens"
-    regex: "\{\s*\([^:]+\)\s*in"
+    regex: '\{\s*(?:\[[^\]]+\])\s*\([^:]+\)\s*in'
+  class_modifier:
+    name: "use static instead of class"
+    regex: '^ *(public|internal|fileprivate|private)? *class +(func|var|let) +'
   class_func:
     name: "class func usage"
-    regex: "^\s*class\s+func\s+"
+    regex: '^\s*class\s+func\s+'
+  closing_braces_without_whitespace:
+    name: "Single newline after closing brace"
+    regex: '^[ ]*\}\n[ ]*[^} \n\.\)#]'
+    match_kinds:
+      - identifier
+      - typeidentifier
+  closing_bracket_without_whitespace:
+    name: "Single newline after closing bracket"
+    regex: '^[ ]*\]\n[ ]*[^]} \n\.\)#]'
+  newline_after_brace:
+    name: "Opening braces shouldn't have empty lines under them"
+    regex: '\{\n\n'
+  newline_before_brace:
+    name: "Closing braces shouldn't have empty lines before them"
+    regex: '\n\n\}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
-`LyftSDK` adheres to [Semantic Versioning](http://semver.org/).
+`LyftSDK` adheres to [Semantic Versioning](https://semver.org/).
+
+## [2.0.0](https://github.com/lyft/Lyft-iOS-sdk/releases/tag/2.0.0)
+
+- Update to Swift 5
+- Add Lux, Lux Black & Lux Black XL ride kinds
 
 ## [1.0.6](https://github.com/lyft/Lyft-iOS-sdk/releases/tag/1.0.6)
 

--- a/Example/LyftSDK-Example.xcodeproj/project.pbxproj
+++ b/Example/LyftSDK-Example.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		607FACE51AFB9204008FA782 /* LyftSDK_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LyftSDK_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6829CC196E8C2CA1537DE07F /* Pods-LyftSDK_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LyftSDK_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-LyftSDK_Example/Pods-LyftSDK_Example.release.xcconfig"; sourceTree = "<group>"; };
-		73AAA64BF20BAB5752EABEFA /* LyftSDK.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LyftSDK.podspec; path = ../LyftSDK.podspec; sourceTree = "<group>"; };
+		73AAA64BF20BAB5752EABEFA /* LyftSDK.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LyftSDK.podspec; path = ../LyftSDK.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		784B9C8BF62374FDD0EB3ACD /* Pods-LyftSDK_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LyftSDK_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-LyftSDK_Tests/Pods-LyftSDK_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		C9835B79E5CF0656ECEEC15A /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		FB12B53F1DAEFE93000439B6 /* HTTPClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClientTests.swift; sourceTree = "<group>"; };
@@ -233,7 +233,6 @@
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
 				523277F8C9FFC4BDB0B7EF04 /* [CP] Embed Pods Frameworks */,
-				2602E9C37C84015FACA5389B /* [CP] Copy Pods Resources */,
 				714F42731D909777008D18C2 /* ShellScript */,
 			);
 			buildRules = (
@@ -254,7 +253,6 @@
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
 				6F635CB291ADB2AB2E1C07CA /* [CP] Embed Pods Frameworks */,
-				F8F46C13B54B2D697427EA01 /* [CP] Copy Pods Resources */,
 				710F44BE1D90981200915DA8 /* ShellScript */,
 			);
 			buildRules = (
@@ -293,6 +291,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -334,34 +333,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2602E9C37C84015FACA5389B /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LyftSDK_Example/Pods-LyftSDK_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		523277F8C9FFC4BDB0B7EF04 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-LyftSDK_Example/Pods-LyftSDK_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/LyftSDK/LyftSDK.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/LyftSDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LyftSDK_Example/Pods-LyftSDK_Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-LyftSDK_Example/Pods-LyftSDK_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6F635CB291ADB2AB2E1C07CA /* [CP] Embed Pods Frameworks */ = {
@@ -370,13 +357,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-LyftSDK_Tests/Pods-LyftSDK_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LyftSDK_Tests/Pods-LyftSDK_Tests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-LyftSDK_Tests/Pods-LyftSDK_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		710F44BE1D90981200915DA8 /* ShellScript */ = {
@@ -403,7 +393,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    cd ${SRCROOT}/../\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    cd ${SRCROOT}/../\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		E68E25157A737C94EACD0B65 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -411,13 +401,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-LyftSDK_Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		EDFF8331686A9D8EB234AA01 /* [CP] Check Pods Manifest.lock */ = {
@@ -426,28 +419,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-LyftSDK_Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		F8F46C13B54B2D697427EA01 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LyftSDK_Tests/Pods-LyftSDK_Tests-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -541,11 +522,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -579,9 +561,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -597,7 +580,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -612,7 +595,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -625,12 +608,12 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LyftSDK_Example.app/LyftSDK_Example";
 			};
 			name = Debug;
@@ -640,12 +623,12 @@
 			baseConfigurationReference = 784B9C8BF62374FDD0EB3ACD /* Pods-LyftSDK_Tests.release.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LyftSDK_Example.app/LyftSDK_Example";
 			};
 			name = Release;

--- a/Example/LyftSDK-Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/LyftSDK-Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/LyftSDK-Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/LyftSDK-Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/LyftSDK-Example/AppDelegate.swift
+++ b/Example/LyftSDK-Example/AppDelegate.swift
@@ -1,10 +1,9 @@
-import UIKit
 import CoreLocation
 import LyftSDK
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
 
     func applicationDidFinishLaunching(_ application: UIApplication) {

--- a/Example/LyftSDK-Example/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/LyftSDK-Example/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -39,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/LyftSDK-Example/ViewController.swift
+++ b/Example/LyftSDK-Example/ViewController.swift
@@ -1,10 +1,9 @@
 import CoreLocation
-import UIKit
 import LyftSDK
+import UIKit
 
 class ViewController: UIViewController {
-
-    @IBOutlet weak var sampleLyftButton: LyftButton!
+    @IBOutlet private weak var sampleLyftButton: LyftButton!
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,3 +1,4 @@
+platform :ios, '9.0'
 use_frameworks!
 
 target 'LyftSDK_Example' do

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - LyftSDK (1.0.3):
-    - LyftSDK/Core (= 1.0.3)
-  - LyftSDK/Core (1.0.3)
+  - LyftSDK (2.0.0):
+    - LyftSDK/Core (= 2.0.0)
+  - LyftSDK/Core (2.0.0)
   - OHHTTPStubs (5.2.1):
     - OHHTTPStubs/Default (= 5.2.1)
   - OHHTTPStubs/Core (5.2.1)
@@ -20,14 +20,18 @@ DEPENDENCIES:
   - LyftSDK (from `../`)
   - OHHTTPStubs
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - OHHTTPStubs
+
 EXTERNAL SOURCES:
   LyftSDK:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  LyftSDK: 36cb780cacc423d36d54ea06649e07337409c5b8
+  LyftSDK: 40dd8873fd2f409e1dd27a66cdad00eef09f576c
   OHHTTPStubs: 3a42f25c00563b71355ac73112ba2324e9e6cef4
 
-PODFILE CHECKSUM: 9ba4e26754fb7c0714263aaa9a831f1d0eeaa91e
+PODFILE CHECKSUM: 3de56f268089fc0d6620d8c8f1035bd16dec7307
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.7.0

--- a/Example/Tests/LyftAPI/HTTPClientTests.swift
+++ b/Example/Tests/LyftAPI/HTTPClientTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 extension String: Routable {
     public var url: URL {
-        return URL(string: "https://test.com")!
+        return URL(staticString: "https://test.com")
     }
 
     public var extraHTTPHeaders: [String: String] {
@@ -13,18 +13,18 @@ extension String: Routable {
 }
 
 final class HTTPClientTests: XCTestCase {
-
     override func tearDown() {
+        super.tearDown()
         OHHTTPStubs.removeAllStubs()
     }
 
     func testSendingParametersUsingURLEncoding() {
         let expectation = self.expectation(description: "response closure is called")
 
-        OHHTTPStubs.stubRequests(passingTest: { _ in true }) { request in
+        OHHTTPStubs.stubRequests(passingTest: { _ in true }, withStubResponse: { request in
             XCTAssertEqual(request.url?.query, "foo=bar")
             return OHHTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
-        }
+        })
 
         HTTPClient().request(.get, "", parameters: ["foo": "bar"]) { _, type in
             XCTAssertEqual(type, .succeed)
@@ -36,9 +36,9 @@ final class HTTPClientTests: XCTestCase {
 
     func testRequestsThat404() {
         let expectation = self.expectation(description: "response closure is called")
-        OHHTTPStubs.stubRequests(passingTest: { _ in true }) { _ in
+        OHHTTPStubs.stubRequests(passingTest: { _ in true }, withStubResponse: { _ in
             return OHHTTPStubsResponse(data: Data(), statusCode: 404, headers: nil)
-        }
+        })
 
         HTTPClient().request(.get, "") { _, type in
             XCTAssertEqual(type, .notFound)

--- a/Example/Tests/LyftModels/MoneyTests.swift
+++ b/Example/Tests/LyftModels/MoneyTests.swift
@@ -3,13 +3,11 @@ import XCTest
 
 private extension Money {
     init(amount: Decimal) {
-        self.amount = amount
-        self.currencyCode = "USD"
+        self.init(amount: amount, currencyCode: "USD")
     }
 }
 
 final class MoneyTests: XCTestCase {
-
     func testEquality() {
         XCTAssert(Money(amount: 5) == Money(amount: 5))
         XCTAssertFalse(Money(amount: 5) == Money(amount: 5, currencyCode: "JPY"))

--- a/Example/Tests/LyftUI/MoneyUITests.swift
+++ b/Example/Tests/LyftUI/MoneyUITests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class MoneyUITests: XCTestCase {
-
     func testItDisplaysDollarValue() {
         XCTAssertEqual(Money(amount: 5, currencyCode: "USD").formattedPrice(), "$5")
     }

--- a/LyftSDK.podspec
+++ b/LyftSDK.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name            = 'LyftSDK'
-  s.version         = '1.0.6'
+  s.version         = '2.0.0'
   s.summary         = 'The official Lyft iOS SDK.'
   s.homepage        = 'https://github.com/lyft/lyft-iOS-sdk'
   s.license         = { :type => 'Apache', :file => 'LICENSE' }
-  s.author          = { 'Gilad Gurantz' => 'gilad@lyft.com' }
+  s.author          = { 'Server Cimen' => 'scimen@lyft.com' }
   s.source          = { :git => 'https://github.com/lyft/lyft-iOS-sdk.git', :tag => s.version.to_s }
   s.default_subspec = 'Core'
   s.ios.deployment_target = '8.0'

--- a/LyftSDK.xcodeproj/project.pbxproj
+++ b/LyftSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2EDE453B22A722E800718EB4 /* URL+StaticString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDE453A22A722E800718EB4 /* URL+StaticString.swift */; };
 		FB7CA7211DD1252800303FEB /* LyftSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB7CA7171DD1252800303FEB /* LyftSDK.framework */; };
 		FB7CA7581DD1256800303FEB /* APIRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7351DD1256800303FEB /* APIRoute.swift */; };
 		FB7CA7591DD1256800303FEB /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB7CA7361DD1256800303FEB /* Bundle+Extension.swift */; };
@@ -52,6 +53,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2EDE453A22A722E800718EB4 /* URL+StaticString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+StaticString.swift"; sourceTree = "<group>"; };
 		FB7CA7171DD1252800303FEB /* LyftSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LyftSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB7CA7201DD1252800303FEB /* LyftSDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LyftSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB7CA7321DD1256800303FEB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -146,6 +148,7 @@
 		FB7CA7341DD1256800303FEB /* LyftAPI */ = {
 			isa = PBXGroup;
 			children = (
+				2EDE453A22A722E800718EB4 /* URL+StaticString.swift */,
 				FB7CA7351DD1256800303FEB /* APIRoute.swift */,
 				FB7CA7361DD1256800303FEB /* Bundle+Extension.swift */,
 				FB7CA7371DD1256800303FEB /* HTTPClient.swift */,
@@ -277,6 +280,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = FB7CA70D1DD1252800303FEB;
@@ -330,6 +334,7 @@
 				FB7CA76D1DD1256800303FEB /* LyftButtonStyle.swift in Sources */,
 				FB7CA76C1DD1256800303FEB /* LyftButton.swift in Sources */,
 				FB7CA75C1DD1256800303FEB /* LyftAPI.swift in Sources */,
+				2EDE453B22A722E800718EB4 /* URL+StaticString.swift in Sources */,
 				FB7CA76B1DD1256800303FEB /* I18N.swift in Sources */,
 				FB7CA7661DD1256800303FEB /* PricingDetails.swift in Sources */,
 				FB7CA7581DD1256800303FEB /* APIRoute.swift in Sources */,
@@ -416,7 +421,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -463,7 +468,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -490,7 +495,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.LyftSDK;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -510,7 +515,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.LyftSDK;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -522,7 +527,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.LyftSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -534,7 +538,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.LyftSDKTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/LyftSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/LyftSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Note that you can specify a LyftDeepLinkBehavior in this request, to decide betw
 
 ## Support
 
-If you're looking for help configuring or using the SDK, or if you have general questions related to our APIs, the Lyft Developer Platform team provides support through our [forum](https://developer.lyft.com/discuss) as well as on Stack Overflow (using the `lyft-api` tag)
+If you're looking for help configuring or using the SDK, or if you have general questions related to our APIs, the Lyft Developer Platform team provides support through Stack Overflow (using the `lyft-api` tag)
 
 ## Reporting security vulnerabilities
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/LyftAPI/APIRoute.swift
+++ b/Sources/LyftAPI/APIRoute.swift
@@ -8,7 +8,7 @@ import Foundation
 /// - nearbyDrivers:    Determine the location of drivers near a location
 enum APIRoute {
     /// Base API URL to create requests from
-    static var baseURL = URL(string: "https://api.lyft.com")!
+    static var baseURL = URL(staticString: "https://api.lyft.com")
 
     case eta
     case rideTypes
@@ -17,25 +17,25 @@ enum APIRoute {
 }
 
 extension APIRoute: Routable {
-
     /// The URL string of the combined URL
     var url: URL {
         let path: String = {
             switch self {
-                case .eta:
-                    return "/v1/eta"
+            case .eta:
+                return "/v1/eta"
 
-                case .rideTypes:
-                    return "/v1/ridetypes"
+            case .rideTypes:
+                return "/v1/ridetypes"
 
-                case .costEstimates:
-                    return "/v1/cost"
+            case .costEstimates:
+                return "/v1/cost"
 
-                case .nearbyDrivers:
-                    return "/v1/drivers"
+            case .nearbyDrivers:
+                return "/v1/drivers"
             }
         }()
 
+        // swiftlint:disable:next force_unwrapping
         return URL(string: path, relativeTo: APIRoute.baseURL)!
     }
 

--- a/Sources/LyftAPI/HTTPClient.swift
+++ b/Sources/LyftAPI/HTTPClient.swift
@@ -79,7 +79,6 @@ public enum ResponseType {
 
 /// Manages request sessions
 final class HTTPClient {
-
     private let session: URLSession
 
     /// Initializes a new instance of HTTPClient
@@ -105,7 +104,7 @@ final class HTTPClient {
                  completion: @escaping (Any?, ResponseType) -> Void)
     {
         let request = self.urlRequest(method: method, route: route, parameters: parameters)
-        let dataTask = self.session.dataTask(with: request) { data, response, error in
+        let dataTask = self.session.dataTask(with: request) { data, response, _ in
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 500
             let status = ResponseType(fromCode: statusCode)
 

--- a/Sources/LyftAPI/JSONMappable.swift
+++ b/Sources/LyftAPI/JSONMappable.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// Represents an object that can be created from a json object
 protocol JSONMappable {
-
     /// Creates an instance from a dictionary
     ///
     /// - parameter json:   A NSDictionary of key object pairs originating from JSON
@@ -29,7 +28,6 @@ extension JSONMappable {
 }
 
 extension Array where Element: JSONMappable {
-
     /// Convenience initializer for creating an array of mappable items
     ///
     /// - parameter json:   The json object representing the array of mappable items
@@ -37,7 +35,7 @@ extension Array where Element: JSONMappable {
     /// - returns:  An array of mapped items if one can be created, or nil otherwise
     init?(json: Any?) {
         if let json = json as? [NSDictionary], json.count > 0 {
-            self = json.flatMap { Element(json: $0) }
+            self = json.compactMap { Element(json: $0) }
         } else {
             return nil
         }

--- a/Sources/LyftAPI/LyftAPI.swift
+++ b/Sources/LyftAPI/LyftAPI.swift
@@ -14,7 +14,6 @@ public struct LyftAPI {
 }
 
 extension LyftAPI {
-
     /// Get the ETA estimates from a specific position by ride kind.
     ///
     /// - parameter position:   The pickup position to get ETAs to.
@@ -70,6 +69,7 @@ extension LyftAPI {
             "start_lat": pickup.latitude,
             "start_lng": pickup.longitude,
         ]
+
         parameters["end_lat"] = destination?.latitude
         parameters["end_lng"] = destination?.longitude
         parameters["ride_type"] = rideKind?.rawValue

--- a/Sources/LyftAPI/LyftAPIURLEncoding.swift
+++ b/Sources/LyftAPI/LyftAPIURLEncoding.swift
@@ -2,11 +2,11 @@ import Foundation
 
 private func components(forKey key: String, value: Any) -> [URLQueryItem] {
     switch value {
-        case let array as [Any]:
-            return array.map { URLQueryItem(name: key, value: String(describing: $0)) }
+    case let array as [Any]:
+        return array.map { URLQueryItem(name: key, value: String(describing: $0)) }
 
-        default:
-            return [URLQueryItem(name: key, value: String(describing: value))]
+    default:
+        return [URLQueryItem(name: key, value: String(describing: value))]
     }
 }
 
@@ -19,17 +19,17 @@ private func components(forKey key: String, value: Any) -> [URLQueryItem] {
 /// - returns: A tuple containing the constructed request and the error that occurred during parameter
 ///            encoding, if any.
 func lyftURLEncodedInURL(request: URLRequest, parameters: [String: Any]?) -> (URLRequest, NSError?) {
-    guard let parameters = parameters else {
+    guard let parameters = parameters, let url = request.url else {
         return (request, nil)
     }
 
+    var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
     var mutableURLRequest = request
     let queryItems = parameters
         .sorted { $0.0 < $1.0 }
         .flatMap { components(forKey: $0, value: $1) }
-
-    var urlComponents = URLComponents(url: mutableURLRequest.url!, resolvingAgainstBaseURL: false)
-    urlComponents?.queryItems = (urlComponents?.queryItems ?? []) + queryItems
+    let existingItems = urlComponents?.queryItems ?? []
+    urlComponents?.queryItems = existingItems + queryItems
     mutableURLRequest.url = urlComponents?.url
     return (mutableURLRequest, nil)
 }

--- a/Sources/LyftAPI/Result.swift
+++ b/Sources/LyftAPI/Result.swift
@@ -1,54 +1,33 @@
-/// A slightly more restrictive implementation of the Either monad. Result has 2 possible outcomes, either a
-/// value `T` or an error `U`. They can be accessed using a `switch` statement with the `Success` or `Failure`
-/// cases, or through the convenience properties to make them optional. You should use a `switch` statement
-/// unless you only care about a single case.
-public enum Result<T, U: Error> {
-    case success(T)
-    case failure(U)
-
-    /// The value if the result is a `Success`, otherwise nil
-    public var value: T? {
-        switch self {
-            case .success(let value):
-                return value
-            case .failure(_):
-                return nil
-        }
-    }
-
-    /// The error if the value is a `Failure`, otherwise nil
-    public var error: U? {
-        switch self {
-            case .success(_):
-                return nil
-            case .failure(let error):
-                return error
-        }
-    }
-
-    /// Create a successful result case with the given value.
-    ///
-    /// - parameter value: The value to store.
-    public init(value: T) {
-        self = .success(value)
-    }
-
-    /// Create a failed result with the given error.
-    ///
-    /// - parameter error: The error to store with the failure case.
-    public init(error: U) {
-        self = .failure(error)
-    }
-
+extension Result {
     /// Create a result with the possible value, or error.
     ///
     /// - parameter value: The value to use with the successful case if it exists.
     /// - parameter error: The error closure to use as the failure case if the value doesn't exist.
-    public init(value: T?, failWith error: @autoclosure () -> U) {
+    init(value: Success?, failWith error: @autoclosure () -> Failure) {
         if let value = value {
             self = .success(value)
         } else {
             self = .failure(error())
+        }
+    }
+
+    /// The value if the result is `success`, otherwise nil.
+    public var value: Success? {
+        switch self {
+        case .success(let value):
+            return value
+        case .failure:
+            return nil
+        }
+    }
+
+    /// The error if the value is `failure`, otherwise nil.
+    public var error: Failure? {
+        switch self {
+        case .success:
+            return nil
+        case .failure(let error):
+            return error
         }
     }
 }

--- a/Sources/LyftAPI/URL+StaticString.swift
+++ b/Sources/LyftAPI/URL+StaticString.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension URL {
+    /// Creates a URL from a static string.
+    ///
+    /// - warning: Only pass valid URLs, or else this will trap at runtime.
+    ///
+    /// - parameter staticString: valid URL string.
+    init(staticString: StaticString) {
+        // swiftlint:disable:next force_unwrapping
+        self.init(string: String(describing: staticString))!
+    }
+}

--- a/Sources/LyftModels/CLLocationCoordinate2D+JSONMappable.swift
+++ b/Sources/LyftModels/CLLocationCoordinate2D+JSONMappable.swift
@@ -1,7 +1,6 @@
 import CoreLocation
 
 extension CLLocationCoordinate2D: JSONMappable {
-
     init?(json: NSDictionary) {
         guard let latitude = json["lat"] as? Double, let longitude = json["lng"] as? Double else {
             return nil

--- a/Sources/LyftModels/Money.swift
+++ b/Sources/LyftModels/Money.swift
@@ -36,7 +36,6 @@ public struct Money {
 // MARK: - Operators overload
 
 extension Money: Comparable {
-
     public static func == (left: Money, right: Money) -> Bool {
         return left.amount == right.amount && left.currencyCode == right.currencyCode
     }

--- a/Sources/LyftModels/RideKind.swift
+++ b/Sources/LyftModels/RideKind.swift
@@ -3,8 +3,6 @@ public struct RideKind: RawRepresentable, Hashable {
     /// The string value of the actual ride kind. For example "lyft_line".
     public var rawValue: String
 
-    public var hashValue: Int { return self.rawValue.hashValue }
-
     private init(_ rawValue: String) {
         self.rawValue = rawValue
     }
@@ -26,10 +24,24 @@ public struct RideKind: RawRepresentable, Hashable {
         }
     }
 
+    // MARK: - Hashable conformance
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.rawValue.hashValue)
+    }
+
+    // MARK: - Ride Kinds
+
     /// Standard lyft ride kind
     public static let Standard = RideKind("lyft")
     /// Lyft Line ride kind
     public static let Line = RideKind("lyft_line")
     /// Lyft plus ride kind
     public static let Plus = RideKind("lyft_plus")
+    /// Lux ride kind
+    public static let Lux = RideKind("lyft_premier")
+    /// Lux Black ride kind
+    public static let LuxBlack = RideKind("lyft_lux")
+    /// Lux Black XL ride kind
+    public static let LuxBlackXL = RideKind("lyft_luxsuv")
 }

--- a/Sources/LyftUI/Asset.swift
+++ b/Sources/LyftUI/Asset.swift
@@ -10,7 +10,6 @@ import UIKit
 /// ```
 /// ... and then you can get an instance of UIImage by doing: `Asset.Car.image()`.
 class Asset {
-
     /// The string value of the asset name
     var rawValue: String
 
@@ -26,8 +25,7 @@ class Asset {
     /// Creates an UIImage using the asset rawValue and given rendering mode.
     ///
     /// - returns: A new image object with the specified rendering mode.
-    func image() -> UIImage?
-    {
+    func image() -> UIImage? {
         return UIImage(named: self.rawValue, in: Bundle(for: type(of: self)), compatibleWith: nil )
     }
 }

--- a/Sources/LyftUI/Button.swift
+++ b/Sources/LyftUI/Button.swift
@@ -2,7 +2,6 @@ import UIKit
 
 /// Button that exposes convenience methods for colors
 class Button: UIButton {
-
     /// Set the Button's highlightedColor from IB
     @IBInspectable var highlightedColor: UIColor? {
         didSet { self.updateStateColors() }

--- a/Sources/LyftUI/I18N.swift
+++ b/Sources/LyftUI/I18N.swift
@@ -8,7 +8,6 @@ private func __(_ key: String) -> String {
 
 /// Struct for managing localizable strings
 struct I18N {
-
     /// Localizable strings related to the LyftButton
     struct LyftButton {
         static let RideETAFormat            = __("RIDE_ETA_FORMAT")

--- a/Sources/LyftUI/LyftButton.swift
+++ b/Sources/LyftUI/LyftButton.swift
@@ -35,7 +35,6 @@ private enum LyftButtonStatus {
 /// To use this, create a UIView, and set the custom class to `LyftButton`
 @IBDesignable
 public class LyftButton: UIView {
-
     @IBOutlet private var button: Button!
     @IBOutlet private var logo: UIImageView!
     @IBOutlet private var mainMessage: UILabel!
@@ -44,7 +43,7 @@ public class LyftButton: UIView {
     @IBOutlet private var price: UILabel?
 
     private var buttonStateView: UIView?
-    private var pressUpAction: ((Void) -> Void)?
+    private var pressUpAction: (() -> Void)?
 
     private var status: LyftButtonStatus = .noData {
         didSet { self.setupNib() }
@@ -108,14 +107,14 @@ public class LyftButton: UIView {
         var cost: Cost?
 
         LyftAPI.ETAs(to: pickup) { [weak self] result in
-            eta = result.value?.filter { $0.rideKind == rideKind }.first ??
-                result.value?.filter { $0.rideKind == .Standard }.first
+            eta = result.value?.first { $0.rideKind == rideKind } ??
+                result.value?.first { $0.rideKind == .Standard }
             self?.configureLayout(cost: cost, eta: eta)
         }
 
         LyftAPI.costEstimates(from: pickup, to: destination) { [weak self] result in
-            cost = result.value?.filter { $0.rideKind == rideKind }.first ??
-                result.value?.filter { $0.rideKind == .Standard }.first
+            cost = result.value?.first { $0.rideKind == rideKind } ??
+                result.value?.first { $0.rideKind == .Standard }
             self?.configureLayout(cost: cost, eta: eta)
         }
     }

--- a/Sources/LyftUI/LyftButtonStyle.swift
+++ b/Sources/LyftUI/LyftButtonStyle.swift
@@ -22,62 +22,62 @@ public enum LyftButtonStyle {
     // Lyft logo icon displayed in the button
     var icon: UIImage? {
         switch self {
-            case .mulberryDark, .hotPink:
-                return Asset.lyftLogoWhite.image()
-            case .mulberryLight:
-                return Asset.lyftLogoMulberry.image()
-            case .multicolor:
-                return Asset.lyftLogoPink.image()
-            case .launcher:
-                return Asset.lyftAppIconPink.image()
+        case .mulberryDark, .hotPink:
+            return Asset.lyftLogoWhite.image()
+        case .mulberryLight:
+            return Asset.lyftLogoMulberry.image()
+        case .multicolor:
+            return Asset.lyftLogoPink.image()
+        case .launcher:
+            return Asset.lyftAppIconPink.image()
         }
     }
 
     /// The prime time image icon
     var primeTimeIcon: UIImage? {
         switch self {
-            case .mulberryDark, .hotPink:
-                return Asset.primeTimeWhite.image()
-            case .mulberryLight, .launcher:
-                return Asset.primeTimeMulberry.image()
-            case .multicolor:
-                return Asset.primeTimeCharcoal.image()
+        case .mulberryDark, .hotPink:
+            return Asset.primeTimeWhite.image()
+        case .mulberryLight, .launcher:
+            return Asset.primeTimeMulberry.image()
+        case .multicolor:
+            return Asset.primeTimeCharcoal.image()
         }
     }
 
     /// Background color of the button
     var backgroundColor: UIColor {
         switch self {
-            case .mulberryDark:
-                return .lyftMulberry()
-            case .hotPink:
-                return .lyftPink()
-            case .mulberryLight, .multicolor, .launcher:
-                return .white
+        case .mulberryDark:
+            return .lyftMulberry()
+        case .hotPink:
+            return .lyftPink()
+        case .mulberryLight, .multicolor, .launcher:
+            return .white
         }
     }
 
     /// Highlight color of the button
     var highlightedColor: UIColor {
         switch self {
-            case .mulberryDark:
-                return .lyftMulberryDark()
-            case .hotPink:
-                return .lyftPinkDark()
-            case .mulberryLight, .multicolor, .launcher:
-                return .lyftWhiteDark()
+        case .mulberryDark:
+            return .lyftMulberryDark()
+        case .hotPink:
+            return .lyftPinkDark()
+        case .mulberryLight, .multicolor, .launcher:
+            return .lyftWhiteDark()
         }
     }
 
     /// Text color of the button
     var foregroundColor: UIColor {
         switch self {
-            case .mulberryDark, .hotPink:
-                return .white
-            case .mulberryLight, .launcher:
-                return .lyftMulberry()
-            case .multicolor:
-                return .lyftCharcoal()
+        case .mulberryDark, .hotPink:
+            return .white
+        case .mulberryLight, .launcher:
+            return .lyftMulberry()
+        case .multicolor:
+            return .lyftCharcoal()
         }
     }
 }

--- a/Sources/LyftUI/LyftDeepLink.swift
+++ b/Sources/LyftUI/LyftDeepLink.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreLocation
+import Foundation
 import UIKit
 
 /// Designates the kind of deeplinking to perform
@@ -9,21 +9,20 @@ import UIKit
 public enum LyftDeepLinkBehavior {
     case native
     case web
-    
-    fileprivate var baseUrl: URL? {
+
+    fileprivate var baseUrl: URL {
         switch self {
         case .native:
-            return URL(string: "lyft://ridetype")
-            
+            return URL(staticString: "lyft://ridetype")
+
         case .web:
-            return URL(string: "https://ride.lyft.com/u")
+            return URL(staticString: "https://ride.lyft.com/u")
         }
     }
 }
 
 /// Collection of deep links into the main Lyft application
 public struct LyftDeepLink {
-    
     /// Prepares to request a ride with the given parameters
     ///
     /// - parameter behavior:       The deep linking mode to use for this deep link
@@ -44,17 +43,18 @@ public struct LyftDeepLink {
         parameters["pickup[longitude]"] = pickup.map { $0.longitude }
         parameters["destination[latitude]"] = destination.map { $0.latitude }
         parameters["destination[longitude]"] = destination.map { $0.longitude }
-        
+
         self.launch(using: behavior, parameters: parameters)
     }
-    
+
     private static func launch(using behavior: LyftDeepLinkBehavior, parameters: [String: Any])
     {
-        let request = lyftURLEncodedInURL(request: URLRequest(url: behavior.baseUrl!), parameters: parameters).0
+        let request = lyftURLEncodedInURL(request: URLRequest(url: behavior.baseUrl),
+                                          parameters: parameters).0
         guard let url = request.url else {
             return
         }
-        
+
         switch behavior {
         case .native:
             if #available(iOS 10.0, *) {
@@ -66,12 +66,12 @@ public struct LyftDeepLink {
             } else {
                 UIApplication.shared.openURL(url)
             }
-            
+
         case .web:
             Safari.openURL(url, from: UIApplication.shared.topViewController)
         }
     }
-    
+
     @available(iOS 10.0, *)
     private static func launchAppStore() {
         let signUp = LyftConfiguration.signUpIdentifier
@@ -85,13 +85,13 @@ public struct LyftDeepLink {
     }
 }
 
-fileprivate extension UIApplication {
-    fileprivate var topViewController: UIViewController? {
+private extension UIApplication {
+    var topViewController: UIViewController? {
         var topController = self.keyWindow?.rootViewController
         while let viewController = topController?.presentedViewController {
             topController = viewController
         }
-        
+
         return topController
     }
 }

--- a/Sources/LyftUI/Money+UI.swift
+++ b/Sources/LyftUI/Money+UI.swift
@@ -3,7 +3,6 @@ import Foundation
 private let kFormatErrorRepresentation = "ERR"
 
 extension Money {
-
     /// The price with the appropriate formatting for the current market.
     ///
     /// - parameter fractionDigits: The number of digits to include in the string
@@ -14,6 +13,6 @@ extension Money {
         formatter.maximumFractionDigits = fractionDigits
         formatter.numberStyle = .currency
         formatter.currencyCode = self.currencyCode
-        return formatter.string(from: self.amount as NSDecimalNumber) ?? kFormatErrorRepresentation
+        return formatter.string(from: NSDecimalNumber(decimal: self.amount)) ?? kFormatErrorRepresentation
     }
 }

--- a/Sources/LyftUI/Safari.swift
+++ b/Sources/LyftUI/Safari.swift
@@ -26,8 +26,8 @@ struct Safari {
 }
 
 @available(iOS 9.0, *)
-fileprivate extension SFSafariViewController {
-    fileprivate class func canOpenURL(_ url: URL) -> Bool {
+private extension SFSafariViewController {
+    static func canOpenURL(_ url: URL) -> Bool {
         return url.host != nil && (url.scheme == "http" || url.scheme == "https")
     }
 }

--- a/Sources/LyftUI/UIColor+Extension.swift
+++ b/Sources/LyftUI/UIColor+Extension.swift
@@ -10,7 +10,6 @@ private struct Color {
 }
 
 extension UIColor {
-
     /// Creates an instance of UIColor based on an RGB value.
     ///
     /// - parameter rgbValue: The Integer representation of the RGB value: Example: 0xFF0000.


### PR DESCRIPTION
Functionality changes:
- Set “Swift Language Version” compiler setting to Swift 5. Update SDK
and example project code to Swift 5 syntax.
- Add ride kinds: lyft_premier (Lux), lyft_lux (Lux Black),
lyft_luxsuv (Lux Black XL)

Housekeeping:
- Use Swift’s Result type instead of in-house implementation
- Update swiftlint rules
- Update example project to use the latest version of the Cocoapods